### PR TITLE
feat: A 파트 SQL 입력 계층 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+CC := clang
+CFLAGS := -std=c99 -Wall -Wextra -Werror -Iinclude
+BUILD_DIR := build
+
+SRC_FILES := $(wildcard src/*.c)
+LIB_SRC_FILES := $(filter-out src/main.c,$(SRC_FILES))
+LIB_OBJECTS := $(patsubst src/%.c,$(BUILD_DIR)/%.o,$(LIB_SRC_FILES))
+APP_OBJECTS := $(patsubst src/%.c,$(BUILD_DIR)/%.o,$(SRC_FILES))
+TEST_SOURCES := $(wildcard tests/test_*.c)
+TEST_BINS := $(patsubst tests/%.c,$(BUILD_DIR)/%,$(TEST_SOURCES))
+TEST_SHELLS := $(wildcard tests/test_*.sh)
+
+FULL_APP_SRCS := src/main.c src/schema.c src/storage.c src/executor.c src/result.c
+APP_TARGET :=
+
+ifeq ($(words $(wildcard $(FULL_APP_SRCS))),$(words $(FULL_APP_SRCS)))
+APP_TARGET := sql_processor
+endif
+
+.PHONY: all test clean
+
+all: $(TEST_BINS) $(APP_TARGET)
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(BUILD_DIR)/%.o: src/%.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/test_%: tests/test_%.c $(LIB_OBJECTS) | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(LIB_OBJECTS) $< -o $@
+
+sql_processor: $(APP_OBJECTS)
+	$(CC) $(CFLAGS) $(APP_OBJECTS) -o $@
+
+test: $(TEST_BINS)
+	@for bin in $(TEST_BINS); do \
+		$$bin; \
+	done
+	@for script in $(TEST_SHELLS); do \
+		sh $$script; \
+	done
+
+clean:
+	rm -rf $(BUILD_DIR) sql_processor

--- a/include/ast.h
+++ b/include/ast.h
@@ -1,0 +1,44 @@
+#ifndef AST_H
+#define AST_H
+
+#include <stddef.h>
+
+typedef enum {
+    VALUE_STRING,
+    VALUE_NUMBER
+} ValueType;
+
+typedef struct {
+    ValueType type;
+    char *text;
+} LiteralValue;
+
+typedef struct {
+    char *table_name;
+    char **columns;
+    size_t column_count;
+    LiteralValue *values;
+    size_t value_count;
+} InsertStatement;
+
+typedef struct {
+    char *table_name;
+    int select_all;
+    char **columns;
+    size_t column_count;
+} SelectStatement;
+
+typedef enum {
+    STMT_INSERT,
+    STMT_SELECT
+} StatementType;
+
+typedef struct {
+    StatementType type;
+    union {
+        InsertStatement insert_stmt;
+        SelectStatement select_stmt;
+    };
+} Statement;
+
+#endif

--- a/include/cli.h
+++ b/include/cli.h
@@ -1,0 +1,13 @@
+#ifndef CLI_H
+#define CLI_H
+
+typedef struct {
+    char *db_dir;
+    char *sql_file;
+    int help_requested;
+} CliOptions;
+
+int parse_cli_args(int argc, char **argv, CliOptions *out_options);
+void print_usage(const char *program_name);
+
+#endif

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,0 +1,38 @@
+#ifndef LEXER_H
+#define LEXER_H
+
+#include <stddef.h>
+
+typedef enum {
+    TOKEN_EOF,
+    TOKEN_IDENTIFIER,
+    TOKEN_STRING,
+    TOKEN_NUMBER,
+    TOKEN_COMMA,
+    TOKEN_LPAREN,
+    TOKEN_RPAREN,
+    TOKEN_SEMICOLON,
+    TOKEN_STAR,
+    TOKEN_INSERT,
+    TOKEN_INTO,
+    TOKEN_VALUES,
+    TOKEN_SELECT,
+    TOKEN_FROM
+} TokenType;
+
+typedef struct {
+    TokenType type;
+    char *text;
+} Token;
+
+typedef struct {
+    Token *items;
+    size_t count;
+    size_t capacity;
+} TokenArray;
+
+int tokenize_sql(const char *sql, TokenArray *out_tokens, char *errbuf, size_t errbuf_size);
+void free_token_array(TokenArray *tokens);
+const char *token_type_name(TokenType type);
+
+#endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -1,0 +1,12 @@
+#ifndef PARSER_H
+#define PARSER_H
+
+#include <stddef.h>
+
+#include "ast.h"
+#include "lexer.h"
+
+int parse_statement(const TokenArray *tokens, Statement *out_stmt, char *errbuf, size_t errbuf_size);
+void free_statement(Statement *stmt);
+
+#endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,11 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <stddef.h>
+
+char *read_text_file(const char *path);
+char *trim_whitespace(char *text);
+char *strdup_safe(const char *src);
+void *xmalloc(size_t size);
+
+#endif

--- a/src/cli.c
+++ b/src/cli.c
@@ -1,0 +1,66 @@
+#include "cli.h"
+
+#include <stdio.h>
+#include <string.h>
+
+enum {
+    STATUS_OK = 0,
+    STATUS_INVALID_ARGS = 1
+};
+
+static void init_options(CliOptions *options) {
+    options->db_dir = NULL;
+    options->sql_file = NULL;
+    options->help_requested = 0;
+}
+
+void print_usage(const char *program_name) {
+    printf("Usage: %s -d <db_dir> -f <sql_file>\n", program_name);
+    printf("       %s --db <db_dir> --file <sql_file>\n", program_name);
+    printf("       %s -h | --help\n", program_name);
+}
+
+int parse_cli_args(int argc, char **argv, CliOptions *out_options) {
+    int i;
+
+    if (out_options == NULL) {
+        return STATUS_INVALID_ARGS;
+    }
+
+    init_options(out_options);
+
+    for (i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+            out_options->help_requested = 1;
+            continue;
+        }
+
+        if (strcmp(argv[i], "-d") == 0 || strcmp(argv[i], "--db") == 0) {
+            if (i + 1 >= argc) {
+                return STATUS_INVALID_ARGS;
+            }
+            out_options->db_dir = argv[++i];
+            continue;
+        }
+
+        if (strcmp(argv[i], "-f") == 0 || strcmp(argv[i], "--file") == 0) {
+            if (i + 1 >= argc) {
+                return STATUS_INVALID_ARGS;
+            }
+            out_options->sql_file = argv[++i];
+            continue;
+        }
+
+        return STATUS_INVALID_ARGS;
+    }
+
+    if (out_options->help_requested) {
+        return STATUS_OK;
+    }
+
+    if (out_options->db_dir == NULL || out_options->sql_file == NULL) {
+        return STATUS_INVALID_ARGS;
+    }
+
+    return STATUS_OK;
+}

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,0 +1,324 @@
+#include "lexer.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h"
+
+enum {
+    STATUS_OK = 0,
+    STATUS_LEX_ERROR = 3
+};
+
+static void set_error(char *errbuf, size_t errbuf_size, const char *message) {
+    if (errbuf != NULL && errbuf_size > 0) {
+        snprintf(errbuf, errbuf_size, "%s", message);
+    }
+}
+
+static int chars_equal_ignore_case(char a, char b) {
+    return toupper((unsigned char)a) == toupper((unsigned char)b);
+}
+
+static int strings_equal_ignore_case(const char *lhs, const char *rhs) {
+    size_t i = 0;
+
+    while (lhs[i] != '\0' && rhs[i] != '\0') {
+        if (!chars_equal_ignore_case(lhs[i], rhs[i])) {
+            return 0;
+        }
+        ++i;
+    }
+
+    return lhs[i] == '\0' && rhs[i] == '\0';
+}
+
+static TokenType keyword_type(const char *text) {
+    if (strings_equal_ignore_case(text, "INSERT")) {
+        return TOKEN_INSERT;
+    }
+    if (strings_equal_ignore_case(text, "INTO")) {
+        return TOKEN_INTO;
+    }
+    if (strings_equal_ignore_case(text, "VALUES")) {
+        return TOKEN_VALUES;
+    }
+    if (strings_equal_ignore_case(text, "SELECT")) {
+        return TOKEN_SELECT;
+    }
+    if (strings_equal_ignore_case(text, "FROM")) {
+        return TOKEN_FROM;
+    }
+    return TOKEN_IDENTIFIER;
+}
+
+static int append_token(TokenArray *tokens, TokenType type, const char *text, char *errbuf, size_t errbuf_size) {
+    Token *grown;
+
+    if (tokens->count == tokens->capacity) {
+        size_t new_capacity = tokens->capacity == 0 ? 8 : tokens->capacity * 2;
+        grown = (Token *)realloc(tokens->items, sizeof(Token) * new_capacity);
+        if (grown == NULL) {
+            set_error(errbuf, errbuf_size, "LEX ERROR: out of memory");
+            return STATUS_LEX_ERROR;
+        }
+        tokens->items = grown;
+        tokens->capacity = new_capacity;
+    }
+
+    tokens->items[tokens->count].type = type;
+    tokens->items[tokens->count].text = strdup_safe(text);
+    if (tokens->items[tokens->count].text == NULL) {
+        set_error(errbuf, errbuf_size, "LEX ERROR: out of memory");
+        return STATUS_LEX_ERROR;
+    }
+
+    tokens->count += 1;
+    return STATUS_OK;
+}
+
+static char *copy_range(const char *start, size_t length) {
+    char *text = (char *)xmalloc(length + 1);
+    memcpy(text, start, length);
+    text[length] = '\0';
+    return text;
+}
+
+static int tokenize_identifier(const char *sql, size_t *index, TokenArray *tokens, char *errbuf, size_t errbuf_size) {
+    size_t start = *index;
+    char *text;
+    TokenType type;
+    int status;
+
+    while (isalnum((unsigned char)sql[*index]) || sql[*index] == '_') {
+        ++(*index);
+    }
+
+    text = copy_range(sql + start, *index - start);
+    type = keyword_type(text);
+    status = append_token(tokens, type, text, errbuf, errbuf_size);
+    free(text);
+    return status;
+}
+
+static int tokenize_number(const char *sql, size_t *index, TokenArray *tokens, char *errbuf, size_t errbuf_size) {
+    size_t start = *index;
+    int seen_dot = 0;
+    char *text;
+    int status;
+
+    if (sql[*index] == '-') {
+        ++(*index);
+    }
+
+    while (isdigit((unsigned char)sql[*index]) || (!seen_dot && sql[*index] == '.')) {
+        if (sql[*index] == '.') {
+            seen_dot = 1;
+            if (!isdigit((unsigned char)sql[*index + 1])) {
+                set_error(errbuf, errbuf_size, "LEX ERROR: invalid number literal");
+                return STATUS_LEX_ERROR;
+            }
+        }
+        ++(*index);
+    }
+
+    text = copy_range(sql + start, *index - start);
+    status = append_token(tokens, TOKEN_NUMBER, text, errbuf, errbuf_size);
+    free(text);
+    return status;
+}
+
+static int append_string_char(char **buffer, size_t *length, size_t *capacity, char ch) {
+    char *grown;
+
+    if (*length + 1 >= *capacity) {
+        size_t new_capacity = *capacity == 0 ? 16 : *capacity * 2;
+        grown = (char *)realloc(*buffer, new_capacity);
+        if (grown == NULL) {
+            return 0;
+        }
+        *buffer = grown;
+        *capacity = new_capacity;
+    }
+
+    (*buffer)[(*length)++] = ch;
+    (*buffer)[*length] = '\0';
+    return 1;
+}
+
+static int tokenize_string(const char *sql, size_t *index, TokenArray *tokens, char *errbuf, size_t errbuf_size) {
+    char *buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int status;
+
+    ++(*index);
+
+    while (sql[*index] != '\0') {
+        char ch = sql[*index];
+
+        if (ch == '\'') {
+            if (sql[*index + 1] == '\'') {
+                if (!append_string_char(&buffer, &length, &capacity, '\'')) {
+                    free(buffer);
+                    set_error(errbuf, errbuf_size, "LEX ERROR: out of memory");
+                    return STATUS_LEX_ERROR;
+                }
+                *index += 2;
+                continue;
+            }
+
+            ++(*index);
+            status = append_token(tokens, TOKEN_STRING, buffer == NULL ? "" : buffer, errbuf, errbuf_size);
+            free(buffer);
+            return status;
+        }
+
+        if (!append_string_char(&buffer, &length, &capacity, ch)) {
+            free(buffer);
+            set_error(errbuf, errbuf_size, "LEX ERROR: out of memory");
+            return STATUS_LEX_ERROR;
+        }
+        ++(*index);
+    }
+
+    free(buffer);
+    set_error(errbuf, errbuf_size, "LEX ERROR: unterminated string literal");
+    return STATUS_LEX_ERROR;
+}
+
+static int tokenize_symbol(char ch, TokenArray *tokens, char *errbuf, size_t errbuf_size) {
+    TokenType type;
+    char text[2];
+
+    text[0] = ch;
+    text[1] = '\0';
+
+    switch (ch) {
+        case ',':
+            type = TOKEN_COMMA;
+            break;
+        case '(':
+            type = TOKEN_LPAREN;
+            break;
+        case ')':
+            type = TOKEN_RPAREN;
+            break;
+        case ';':
+            type = TOKEN_SEMICOLON;
+            break;
+        case '*':
+            type = TOKEN_STAR;
+            break;
+        default:
+            set_error(errbuf, errbuf_size, "LEX ERROR: invalid character");
+            return STATUS_LEX_ERROR;
+    }
+
+    return append_token(tokens, type, text, errbuf, errbuf_size);
+}
+
+int tokenize_sql(const char *sql, TokenArray *out_tokens, char *errbuf, size_t errbuf_size) {
+    size_t index = 0;
+    int status = STATUS_OK;
+
+    if (out_tokens == NULL || sql == NULL) {
+        set_error(errbuf, errbuf_size, "LEX ERROR: invalid input");
+        return STATUS_LEX_ERROR;
+    }
+
+    out_tokens->items = NULL;
+    out_tokens->count = 0;
+    out_tokens->capacity = 0;
+
+    if (errbuf != NULL && errbuf_size > 0) {
+        errbuf[0] = '\0';
+    }
+
+    while (sql[index] != '\0') {
+        char ch = sql[index];
+
+        if (isspace((unsigned char)ch)) {
+            ++index;
+            continue;
+        }
+
+        if (isalpha((unsigned char)ch) || ch == '_') {
+            status = tokenize_identifier(sql, &index, out_tokens, errbuf, errbuf_size);
+        } else if (isdigit((unsigned char)ch) || (ch == '-' && isdigit((unsigned char)sql[index + 1]))) {
+            status = tokenize_number(sql, &index, out_tokens, errbuf, errbuf_size);
+        } else if (ch == '\'') {
+            status = tokenize_string(sql, &index, out_tokens, errbuf, errbuf_size);
+        } else {
+            status = tokenize_symbol(ch, out_tokens, errbuf, errbuf_size);
+            ++index;
+        }
+
+        if (status != STATUS_OK) {
+            free_token_array(out_tokens);
+            return status;
+        }
+    }
+
+    status = append_token(out_tokens, TOKEN_EOF, "", errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_token_array(out_tokens);
+        return status;
+    }
+
+    return STATUS_OK;
+}
+
+void free_token_array(TokenArray *tokens) {
+    size_t i;
+
+    if (tokens == NULL) {
+        return;
+    }
+
+    for (i = 0; i < tokens->count; ++i) {
+        free(tokens->items[i].text);
+    }
+
+    free(tokens->items);
+    tokens->items = NULL;
+    tokens->count = 0;
+    tokens->capacity = 0;
+}
+
+const char *token_type_name(TokenType type) {
+    switch (type) {
+        case TOKEN_EOF:
+            return "TOKEN_EOF";
+        case TOKEN_IDENTIFIER:
+            return "TOKEN_IDENTIFIER";
+        case TOKEN_STRING:
+            return "TOKEN_STRING";
+        case TOKEN_NUMBER:
+            return "TOKEN_NUMBER";
+        case TOKEN_COMMA:
+            return "TOKEN_COMMA";
+        case TOKEN_LPAREN:
+            return "TOKEN_LPAREN";
+        case TOKEN_RPAREN:
+            return "TOKEN_RPAREN";
+        case TOKEN_SEMICOLON:
+            return "TOKEN_SEMICOLON";
+        case TOKEN_STAR:
+            return "TOKEN_STAR";
+        case TOKEN_INSERT:
+            return "TOKEN_INSERT";
+        case TOKEN_INTO:
+            return "TOKEN_INTO";
+        case TOKEN_VALUES:
+            return "TOKEN_VALUES";
+        case TOKEN_SELECT:
+            return "TOKEN_SELECT";
+        case TOKEN_FROM:
+            return "TOKEN_FROM";
+        default:
+            return "TOKEN_UNKNOWN";
+    }
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,0 +1,412 @@
+#include "parser.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h"
+
+enum {
+    STATUS_OK = 0,
+    STATUS_PARSE_ERROR = 4
+};
+
+typedef struct {
+    const TokenArray *tokens;
+    size_t current;
+} Parser;
+
+static void set_error(char *errbuf, size_t errbuf_size, const char *message) {
+    if (errbuf != NULL && errbuf_size > 0) {
+        snprintf(errbuf, errbuf_size, "%s", message);
+    }
+}
+
+static void free_string_list(char **items, size_t count) {
+    size_t i;
+
+    if (items == NULL) {
+        return;
+    }
+
+    for (i = 0; i < count; ++i) {
+        free(items[i]);
+    }
+    free(items);
+}
+
+static void free_literal_list(LiteralValue *items, size_t count) {
+    size_t i;
+
+    if (items == NULL) {
+        return;
+    }
+
+    for (i = 0; i < count; ++i) {
+        free(items[i].text);
+    }
+    free(items);
+}
+
+static const Token *parser_peek(Parser *parser) {
+    return &parser->tokens->items[parser->current];
+}
+
+static const Token *parser_previous(Parser *parser) {
+    return &parser->tokens->items[parser->current - 1];
+}
+
+static const Token *parser_advance(Parser *parser) {
+    if (parser_peek(parser)->type != TOKEN_EOF) {
+        ++parser->current;
+    }
+    return parser_previous(parser);
+}
+
+static int parser_match(Parser *parser, TokenType type) {
+    if (parser_peek(parser)->type != type) {
+        return 0;
+    }
+    parser_advance(parser);
+    return 1;
+}
+
+static int parser_expect(Parser *parser, TokenType type, char *errbuf, size_t errbuf_size) {
+    if (parser_match(parser, type)) {
+        return STATUS_OK;
+    }
+
+    set_error(errbuf, errbuf_size, "PARSE ERROR: unexpected token");
+    return STATUS_PARSE_ERROR;
+}
+
+static int parser_expect_with_message(Parser *parser, TokenType type, const char *message, char *errbuf, size_t errbuf_size) {
+    if (parser_match(parser, type)) {
+        return STATUS_OK;
+    }
+
+    set_error(errbuf, errbuf_size, message);
+    return STATUS_PARSE_ERROR;
+}
+
+static int append_identifier(char ***out_items, size_t *out_count, const char *text) {
+    char **grown = (char **)realloc(*out_items, sizeof(char *) * (*out_count + 1));
+    if (grown == NULL) {
+        return 0;
+    }
+
+    *out_items = grown;
+    (*out_items)[*out_count] = strdup_safe(text);
+    if ((*out_items)[*out_count] == NULL) {
+        return 0;
+    }
+    ++(*out_count);
+    return 1;
+}
+
+static int append_literal(LiteralValue **out_items, size_t *out_count, ValueType type, const char *text) {
+    LiteralValue *grown = (LiteralValue *)realloc(*out_items, sizeof(LiteralValue) * (*out_count + 1));
+    if (grown == NULL) {
+        return 0;
+    }
+
+    *out_items = grown;
+    (*out_items)[*out_count].type = type;
+    (*out_items)[*out_count].text = strdup_safe(text);
+    if ((*out_items)[*out_count].text == NULL) {
+        return 0;
+    }
+    ++(*out_count);
+    return 1;
+}
+
+static int parse_identifier(Parser *parser, char **out_text, char *errbuf, size_t errbuf_size) {
+    if (parser_peek(parser)->type != TOKEN_IDENTIFIER) {
+        set_error(errbuf, errbuf_size, "PARSE ERROR: expected identifier");
+        return STATUS_PARSE_ERROR;
+    }
+
+    *out_text = strdup_safe(parser_advance(parser)->text);
+    if (*out_text == NULL) {
+        set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+        return STATUS_PARSE_ERROR;
+    }
+    return STATUS_OK;
+}
+
+static int parse_literal(Parser *parser, LiteralValue *out_value, char *errbuf, size_t errbuf_size) {
+    const Token *token = parser_peek(parser);
+
+    if (token->type == TOKEN_STRING) {
+        out_value->type = VALUE_STRING;
+        out_value->text = strdup_safe(token->text);
+        if (out_value->text == NULL) {
+            set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+            return STATUS_PARSE_ERROR;
+        }
+        parser_advance(parser);
+        return STATUS_OK;
+    }
+
+    if (token->type == TOKEN_NUMBER) {
+        out_value->type = VALUE_NUMBER;
+        out_value->text = strdup_safe(token->text);
+        if (out_value->text == NULL) {
+            set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+            return STATUS_PARSE_ERROR;
+        }
+        parser_advance(parser);
+        return STATUS_OK;
+    }
+
+    set_error(errbuf, errbuf_size, "PARSE ERROR: expected literal");
+    return STATUS_PARSE_ERROR;
+}
+
+static int parse_identifier_list(Parser *parser, char ***out_items, size_t *out_count,
+                                 char *errbuf, size_t errbuf_size) {
+    char *identifier = NULL;
+    int status;
+
+    *out_items = NULL;
+    *out_count = 0;
+
+    status = parse_identifier(parser, &identifier, errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        return status;
+    }
+
+    if (!append_identifier(out_items, out_count, identifier)) {
+        free(identifier);
+        set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+        return STATUS_PARSE_ERROR;
+    }
+    free(identifier);
+
+    while (parser_match(parser, TOKEN_COMMA)) {
+        status = parse_identifier(parser, &identifier, errbuf, errbuf_size);
+        if (status != STATUS_OK) {
+            free_string_list(*out_items, *out_count);
+            *out_items = NULL;
+            *out_count = 0;
+            return status;
+        }
+
+        if (!append_identifier(out_items, out_count, identifier)) {
+            free(identifier);
+            free_string_list(*out_items, *out_count);
+            *out_items = NULL;
+            *out_count = 0;
+            set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+            return STATUS_PARSE_ERROR;
+        }
+        free(identifier);
+    }
+
+    return STATUS_OK;
+}
+
+static int parse_literal_list(Parser *parser, LiteralValue **out_items, size_t *out_count,
+                              char *errbuf, size_t errbuf_size) {
+    LiteralValue literal;
+    int status;
+
+    *out_items = NULL;
+    *out_count = 0;
+
+    literal.type = VALUE_STRING;
+    literal.text = NULL;
+    status = parse_literal(parser, &literal, errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        return status;
+    }
+
+    if (!append_literal(out_items, out_count, literal.type, literal.text)) {
+        free(literal.text);
+        set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+        return STATUS_PARSE_ERROR;
+    }
+    free(literal.text);
+
+    while (parser_match(parser, TOKEN_COMMA)) {
+        literal.type = VALUE_STRING;
+        literal.text = NULL;
+        status = parse_literal(parser, &literal, errbuf, errbuf_size);
+        if (status != STATUS_OK) {
+            free_literal_list(*out_items, *out_count);
+            *out_items = NULL;
+            *out_count = 0;
+            return status;
+        }
+
+        if (!append_literal(out_items, out_count, literal.type, literal.text)) {
+            free(literal.text);
+            free_literal_list(*out_items, *out_count);
+            *out_items = NULL;
+            *out_count = 0;
+            set_error(errbuf, errbuf_size, "PARSE ERROR: out of memory");
+            return STATUS_PARSE_ERROR;
+        }
+        free(literal.text);
+    }
+
+    return STATUS_OK;
+}
+
+static int parse_insert(Parser *parser, Statement *out_stmt, char *errbuf, size_t errbuf_size) {
+    InsertStatement *stmt = &out_stmt->insert_stmt;
+    int status;
+
+    memset(stmt, 0, sizeof(*stmt));
+
+    status = parser_expect_with_message(parser, TOKEN_INTO, "PARSE ERROR: expected INTO after INSERT", errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        return status;
+    }
+
+    status = parse_identifier(parser, &stmt->table_name, errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        return status;
+    }
+
+    if (parser_match(parser, TOKEN_LPAREN)) {
+        status = parse_identifier_list(parser, &stmt->columns, &stmt->column_count, errbuf, errbuf_size);
+        if (status != STATUS_OK) {
+            free_statement(out_stmt);
+            return status;
+        }
+
+        status = parser_expect_with_message(parser, TOKEN_RPAREN, "PARSE ERROR: expected ')' after column list", errbuf, errbuf_size);
+        if (status != STATUS_OK) {
+            free_statement(out_stmt);
+            return status;
+        }
+    }
+
+    status = parser_expect_with_message(parser, TOKEN_VALUES, "PARSE ERROR: expected VALUES in INSERT statement", errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_statement(out_stmt);
+        return status;
+    }
+
+    status = parser_expect_with_message(parser, TOKEN_LPAREN, "PARSE ERROR: expected '(' before value list", errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_statement(out_stmt);
+        return status;
+    }
+
+    status = parse_literal_list(parser, &stmt->values, &stmt->value_count, errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_statement(out_stmt);
+        return status;
+    }
+
+    status = parser_expect_with_message(parser, TOKEN_RPAREN, "PARSE ERROR: expected ')' after value list", errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_statement(out_stmt);
+        return status;
+    }
+
+    out_stmt->type = STMT_INSERT;
+    return STATUS_OK;
+}
+
+static int parse_select(Parser *parser, Statement *out_stmt, char *errbuf, size_t errbuf_size) {
+    SelectStatement *stmt = &out_stmt->select_stmt;
+    int status;
+
+    memset(stmt, 0, sizeof(*stmt));
+
+    if (parser_match(parser, TOKEN_STAR)) {
+        stmt->select_all = 1;
+    } else {
+        status = parse_identifier_list(parser, &stmt->columns, &stmt->column_count, errbuf, errbuf_size);
+        if (status != STATUS_OK) {
+            return status;
+        }
+    }
+
+    status = parser_expect_with_message(parser, TOKEN_FROM, "PARSE ERROR: expected FROM after select list", errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_statement(out_stmt);
+        return status;
+    }
+
+    status = parse_identifier(parser, &stmt->table_name, errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        free_statement(out_stmt);
+        return status;
+    }
+
+    out_stmt->type = STMT_SELECT;
+    return STATUS_OK;
+}
+
+int parse_statement(const TokenArray *tokens, Statement *out_stmt, char *errbuf, size_t errbuf_size) {
+    Parser parser;
+    int status;
+
+    if (tokens == NULL || out_stmt == NULL || tokens->count == 0 || tokens->items == NULL) {
+        set_error(errbuf, errbuf_size, "PARSE ERROR: invalid token stream");
+        return STATUS_PARSE_ERROR;
+    }
+
+    if (errbuf != NULL && errbuf_size > 0) {
+        errbuf[0] = '\0';
+    }
+
+    memset(out_stmt, 0, sizeof(*out_stmt));
+    parser.tokens = tokens;
+    parser.current = 0;
+
+    if (parser_match(&parser, TOKEN_INSERT)) {
+        out_stmt->type = STMT_INSERT;
+        status = parse_insert(&parser, out_stmt, errbuf, errbuf_size);
+    } else if (parser_match(&parser, TOKEN_SELECT)) {
+        out_stmt->type = STMT_SELECT;
+        status = parse_select(&parser, out_stmt, errbuf, errbuf_size);
+    } else {
+        set_error(errbuf, errbuf_size, "PARSE ERROR: expected INSERT or SELECT");
+        return STATUS_PARSE_ERROR;
+    }
+
+    if (status != STATUS_OK) {
+        return status;
+    }
+
+    if (parser_match(&parser, TOKEN_SEMICOLON)) {
+        /* optional */
+    }
+
+    if (parser_expect(&parser, TOKEN_EOF, errbuf, errbuf_size) != STATUS_OK) {
+        free_statement(out_stmt);
+        set_error(errbuf, errbuf_size, "PARSE ERROR: unexpected trailing tokens");
+        return STATUS_PARSE_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
+void free_statement(Statement *stmt) {
+    if (stmt == NULL) {
+        return;
+    }
+
+    if (stmt->type == STMT_INSERT) {
+        free(stmt->insert_stmt.table_name);
+        free_string_list(stmt->insert_stmt.columns, stmt->insert_stmt.column_count);
+        free_literal_list(stmt->insert_stmt.values, stmt->insert_stmt.value_count);
+        stmt->insert_stmt.table_name = NULL;
+        stmt->insert_stmt.columns = NULL;
+        stmt->insert_stmt.column_count = 0;
+        stmt->insert_stmt.values = NULL;
+        stmt->insert_stmt.value_count = 0;
+    } else if (stmt->type == STMT_SELECT) {
+        free(stmt->select_stmt.table_name);
+        free_string_list(stmt->select_stmt.columns, stmt->select_stmt.column_count);
+        stmt->select_stmt.table_name = NULL;
+        stmt->select_stmt.columns = NULL;
+        stmt->select_stmt.column_count = 0;
+        stmt->select_stmt.select_all = 0;
+    }
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,102 @@
+#include "utils.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void *xmalloc(size_t size) {
+    void *ptr = malloc(size == 0 ? 1 : size);
+    if (ptr == NULL) {
+        fprintf(stderr, "out of memory\n");
+        exit(EXIT_FAILURE);
+    }
+    return ptr;
+}
+
+char *strdup_safe(const char *src) {
+    size_t len;
+    char *copy;
+
+    if (src == NULL) {
+        return NULL;
+    }
+
+    len = strlen(src);
+    copy = (char *)xmalloc(len + 1);
+    memcpy(copy, src, len + 1);
+    return copy;
+}
+
+char *trim_whitespace(char *text) {
+    char *end;
+
+    if (text == NULL) {
+        return NULL;
+    }
+
+    while (*text != '\0' && isspace((unsigned char)*text)) {
+        ++text;
+    }
+
+    if (*text == '\0') {
+        return text;
+    }
+
+    end = text + strlen(text) - 1;
+    while (end > text && isspace((unsigned char)*end)) {
+        *end = '\0';
+        --end;
+    }
+
+    return text;
+}
+
+char *read_text_file(const char *path) {
+    FILE *file;
+    long size;
+    size_t bytes_read;
+    char *buffer;
+
+    if (path == NULL) {
+        return NULL;
+    }
+
+    file = fopen(path, "rb");
+    if (file == NULL) {
+        return NULL;
+    }
+
+    if (fseek(file, 0L, SEEK_END) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    size = ftell(file);
+    if (size <= 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    if (fseek(file, 0L, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    buffer = (char *)malloc((size_t)size + 1);
+    if (buffer == NULL) {
+        fclose(file);
+        return NULL;
+    }
+
+    bytes_read = fread(buffer, 1, (size_t)size, file);
+    fclose(file);
+
+    if (bytes_read != (size_t)size) {
+        free(buffer);
+        return NULL;
+    }
+
+    buffer[size] = '\0';
+    return buffer;
+}

--- a/tests/test_lexer.c
+++ b/tests/test_lexer.c
@@ -1,0 +1,130 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "lexer.h"
+
+enum {
+    STATUS_OK = 0,
+    STATUS_LEX_ERROR = 3
+};
+
+static void fail(const char *message) {
+    fprintf(stderr, "test_lexer failed: %s\n", message);
+    exit(1);
+}
+
+static void assert_int_eq(int expected, int actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr, "test_lexer failed: %s (expected=%d actual=%d)\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void assert_str_eq(const char *expected, const char *actual, const char *message) {
+    if (strcmp(expected, actual) != 0) {
+        fprintf(stderr, "test_lexer failed: %s (expected=%s actual=%s)\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void test_insert_tokens(void) {
+    TokenArray tokens = {0};
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_sql("INSERT INTO users VALUES (1, 'Alice');", &tokens, errbuf, sizeof(errbuf)),
+                  "INSERT tokenization should succeed");
+    assert_int_eq(TOKEN_INSERT, tokens.items[0].type, "first token should be INSERT");
+    assert_int_eq(TOKEN_INTO, tokens.items[1].type, "second token should be INTO");
+    assert_int_eq(TOKEN_IDENTIFIER, tokens.items[2].type, "table name should be identifier");
+    assert_str_eq("users", tokens.items[2].text, "table name should match");
+    assert_int_eq(TOKEN_VALUES, tokens.items[3].type, "VALUES token should exist");
+    assert_int_eq(TOKEN_NUMBER, tokens.items[5].type, "numeric literal should be number");
+    assert_str_eq("1", tokens.items[5].text, "numeric literal text should match");
+    assert_int_eq(TOKEN_STRING, tokens.items[7].type, "string literal should be string token");
+    assert_str_eq("Alice", tokens.items[7].text, "string literal should be unquoted");
+    assert_int_eq(TOKEN_EOF, tokens.items[tokens.count - 1].type, "EOF token should be appended");
+
+    free_token_array(&tokens);
+}
+
+static void test_select_star_tokens(void) {
+    TokenArray tokens = {0};
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_sql("SELECT * FROM users;", &tokens, errbuf, sizeof(errbuf)),
+                  "SELECT * should tokenize");
+    assert_int_eq(TOKEN_SELECT, tokens.items[0].type, "SELECT keyword should match");
+    assert_int_eq(TOKEN_STAR, tokens.items[1].type, "* token should match");
+    assert_int_eq(TOKEN_FROM, tokens.items[2].type, "FROM keyword should match");
+    assert_str_eq("users", tokens.items[3].text, "table name should match");
+
+    free_token_array(&tokens);
+}
+
+static void test_select_column_tokens(void) {
+    TokenArray tokens = {0};
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_sql("select id, name FROM users;", &tokens, errbuf, sizeof(errbuf)),
+                  "column projection should tokenize");
+    assert_int_eq(TOKEN_SELECT, tokens.items[0].type, "keyword should be case-insensitive");
+    assert_int_eq(TOKEN_IDENTIFIER, tokens.items[1].type, "first column should be identifier");
+    assert_str_eq("id", tokens.items[1].text, "first column text should match");
+    assert_int_eq(TOKEN_COMMA, tokens.items[2].type, "comma token should exist");
+    assert_str_eq("name", tokens.items[3].text, "second column text should match");
+
+    free_token_array(&tokens);
+}
+
+static void test_string_and_number_literals(void) {
+    TokenArray tokens = {0};
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_sql("INSERT INTO books VALUES ('O''Reilly', -7, 3.14);", &tokens, errbuf, sizeof(errbuf)),
+                  "escaped string and numbers should tokenize");
+    assert_str_eq("O'Reilly", tokens.items[5].text, "escaped string should be unescaped");
+    assert_str_eq("-7", tokens.items[7].text, "negative integer should match");
+    assert_str_eq("3.14", tokens.items[9].text, "decimal literal should match");
+
+    free_token_array(&tokens);
+}
+
+static void test_invalid_character_fails(void) {
+    TokenArray tokens = {0};
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_LEX_ERROR,
+                  tokenize_sql("SELECT @ FROM users;", &tokens, errbuf, sizeof(errbuf)),
+                  "invalid character should fail");
+    if (strstr(errbuf, "LEX ERROR") == NULL) {
+        fail("error message should mention LEX ERROR");
+    }
+}
+
+static void test_unterminated_string_fails(void) {
+    TokenArray tokens = {0};
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_LEX_ERROR,
+                  tokenize_sql("INSERT INTO users VALUES ('Alice);", &tokens, errbuf, sizeof(errbuf)),
+                  "unterminated string should fail");
+    if (strstr(errbuf, "unterminated string literal") == NULL) {
+        fail("unterminated string message should be present");
+    }
+}
+
+int main(void) {
+    test_insert_tokens();
+    test_select_star_tokens();
+    test_select_column_tokens();
+    test_string_and_number_literals();
+    test_invalid_character_fails();
+    test_unterminated_string_fails();
+    printf("test_lexer: OK\n");
+    return 0;
+}

--- a/tests/test_parser.c
+++ b/tests/test_parser.c
@@ -1,0 +1,171 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "parser.h"
+
+enum {
+    STATUS_OK = 0,
+    STATUS_LEX_ERROR = 3,
+    STATUS_PARSE_ERROR = 4
+};
+
+static void fail(const char *message) {
+    fprintf(stderr, "test_parser failed: %s\n", message);
+    exit(1);
+}
+
+static void assert_int_eq(int expected, int actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr, "test_parser failed: %s (expected=%d actual=%d)\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void assert_size_eq(size_t expected, size_t actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr, "test_parser failed: %s (expected=%zu actual=%zu)\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void assert_str_eq(const char *expected, const char *actual, const char *message) {
+    if (strcmp(expected, actual) != 0) {
+        fprintf(stderr, "test_parser failed: %s (expected=%s actual=%s)\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static int tokenize_and_parse(const char *sql, Statement *stmt, char *errbuf, size_t errbuf_size) {
+    TokenArray tokens = {0};
+    int status = tokenize_sql(sql, &tokens, errbuf, errbuf_size);
+    if (status != STATUS_OK) {
+        return status;
+    }
+
+    status = parse_statement(&tokens, stmt, errbuf, errbuf_size);
+    free_token_array(&tokens);
+    return status;
+}
+
+static void test_insert_without_column_list(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_and_parse("INSERT INTO users VALUES (1, 'Alice', 20);", &stmt, errbuf, sizeof(errbuf)),
+                  "INSERT without column list should parse");
+    assert_int_eq(STMT_INSERT, stmt.type, "statement type should be INSERT");
+    assert_str_eq("users", stmt.insert_stmt.table_name, "table name should match");
+    assert_size_eq(0, stmt.insert_stmt.column_count, "column list should be omitted");
+    assert_size_eq(3, stmt.insert_stmt.value_count, "value count should match");
+    assert_int_eq(VALUE_NUMBER, stmt.insert_stmt.values[0].type, "first value should be number");
+    assert_str_eq("1", stmt.insert_stmt.values[0].text, "first number text should match");
+    assert_int_eq(VALUE_STRING, stmt.insert_stmt.values[1].type, "second value should be string");
+    assert_str_eq("Alice", stmt.insert_stmt.values[1].text, "string text should match");
+    free_statement(&stmt);
+}
+
+static void test_insert_with_column_list(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_and_parse("INSERT INTO users (name, id) VALUES ('Bob', 2);", &stmt, errbuf, sizeof(errbuf)),
+                  "INSERT with column list should parse");
+    assert_size_eq(2, stmt.insert_stmt.column_count, "column count should match");
+    assert_str_eq("name", stmt.insert_stmt.columns[0], "first column should match");
+    assert_str_eq("id", stmt.insert_stmt.columns[1], "second column should match");
+    assert_str_eq("Bob", stmt.insert_stmt.values[0].text, "first literal should match");
+    assert_str_eq("2", stmt.insert_stmt.values[1].text, "second literal should match");
+    free_statement(&stmt);
+}
+
+static void test_select_star(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_and_parse("SELECT * FROM users", &stmt, errbuf, sizeof(errbuf)),
+                  "SELECT * without semicolon should parse");
+    assert_int_eq(STMT_SELECT, stmt.type, "statement type should be SELECT");
+    assert_int_eq(1, stmt.select_stmt.select_all, "select_all should be enabled");
+    assert_size_eq(0, stmt.select_stmt.column_count, "column count should be zero for select all");
+    assert_str_eq("users", stmt.select_stmt.table_name, "table name should match");
+    free_statement(&stmt);
+}
+
+static void test_select_column_list(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_OK,
+                  tokenize_and_parse("SELECT id, name FROM users;", &stmt, errbuf, sizeof(errbuf)),
+                  "SELECT projection should parse");
+    assert_int_eq(0, stmt.select_stmt.select_all, "projection should not be select_all");
+    assert_size_eq(2, stmt.select_stmt.column_count, "projection column count should match");
+    assert_str_eq("id", stmt.select_stmt.columns[0], "first projection column should match");
+    assert_str_eq("name", stmt.select_stmt.columns[1], "second projection column should match");
+    free_statement(&stmt);
+}
+
+static void test_select_missing_projection_fails(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_PARSE_ERROR,
+                  tokenize_and_parse("SELECT FROM users;", &stmt, errbuf, sizeof(errbuf)),
+                  "missing projection should fail");
+    if (strstr(errbuf, "PARSE ERROR") == NULL) {
+        fail("parse error message should be present");
+    }
+}
+
+static void test_insert_missing_into_fails(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_PARSE_ERROR,
+                  tokenize_and_parse("INSERT users VALUES (1);", &stmt, errbuf, sizeof(errbuf)),
+                  "missing INTO should fail");
+    if (strstr(errbuf, "expected INTO") == NULL) {
+        fail("missing INTO message should be present");
+    }
+}
+
+static void test_missing_from_fails(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_PARSE_ERROR,
+                  tokenize_and_parse("SELECT id, name users;", &stmt, errbuf, sizeof(errbuf)),
+                  "missing FROM should fail");
+    if (strstr(errbuf, "expected FROM") == NULL) {
+        fail("missing FROM message should be present");
+    }
+}
+
+static void test_missing_comma_or_paren_fails(void) {
+    Statement stmt;
+    char errbuf[256] = {0};
+
+    assert_int_eq(STATUS_PARSE_ERROR,
+                  tokenize_and_parse("INSERT INTO users (id name) VALUES (1, 'Alice');", &stmt, errbuf, sizeof(errbuf)),
+                  "missing comma in column list should fail");
+    assert_int_eq(STATUS_PARSE_ERROR,
+                  tokenize_and_parse("INSERT INTO users (id, name VALUES (1, 'Alice');", &stmt, errbuf, sizeof(errbuf)),
+                  "missing right paren should fail");
+}
+
+int main(void) {
+    test_insert_without_column_list();
+    test_insert_with_column_list();
+    test_select_star();
+    test_select_column_list();
+    test_select_missing_projection_fails();
+    test_insert_missing_into_fails();
+    test_missing_from_fails();
+    test_missing_comma_or_paren_fails();
+    printf("test_parser: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## 요약
A 파트 범위의 SQL 입력 계층을 구현했습니다. 공통 계약에 맞는 CLI, 파일 유틸, lexer, parser, AST 메모리 해제를 추가해 SQL 문자열을 `Statement`까지 변환할 수 있도록 구성했습니다.

## 변경 사항
- A 파트 public header 추가: `ast.h`, `cli.h`, `lexer.h`, `parser.h`, `utils.h`
- `-d/--db`, `-f/--file`, `-h/--help`를 처리하는 CLI 옵션 파서 구현
- SQL 파일 읽기와 문자열 헬퍼 유틸 구현
- `INSERT`, `SELECT`, 식별자, 숫자, 문자열, 괄호, 콤마, 세미콜론, `*`를 처리하는 lexer 구현
- `INSERT INTO ... VALUES ...`, `SELECT * FROM ...`, `SELECT col1, col2 FROM ...` 문법을 AST로 변환하는 parser 구현
- `free_token_array`, `free_statement` 메모리 해제 경로 구현
- lexer/parser 단위 테스트 추가
- Makefile 기반 빌드 및 테스트 타깃 구성

## 테스트
- `make`
- `make test`

## 비고
- 현재 PR은 A 파트 범위만 포함합니다.
- schema/storage/executor/result/main 통합은 이후 B/C 파트 작업과 연결됩니다.
- 로컬의 `.DS_Store`, `build/` 변경은 커밋하지 않아 PR에 포함되지 않습니다.

Closes #1
