### PR TITLE
feat: schema/storage 레이어 구현

### DIFF
--- a/db/products.schema
+++ b/db/products.schema
@@ -1,0 +1,3 @@
+id
+name
+price

--- a/db/users.schema
+++ b/db/users.schema
@@ -1,0 +1,3 @@
+id
+name
+age

--- a/include/schema.h
+++ b/include/schema.h
@@ -1,0 +1,24 @@
+#ifndef SCHEMA_H
+#define SCHEMA_H
+
+#include <stddef.h>
+
+typedef struct {
+    char *table_name;
+    char **columns;
+    size_t column_count;
+} TableSchema;
+
+typedef struct {
+    char **values;
+    size_t value_count;
+} Row;
+
+int load_table_schema(const char *db_dir, const char *table_name,
+                      TableSchema *out_schema,
+                      char *errbuf, size_t errbuf_size);
+
+int schema_find_column_index(const TableSchema *schema, const char *column_name);
+void free_table_schema(TableSchema *schema);
+
+#endif

--- a/include/storage.h
+++ b/include/storage.h
@@ -1,0 +1,22 @@
+#ifndef STORAGE_H
+#define STORAGE_H
+
+#include <stddef.h>
+
+#include "schema.h"
+
+int ensure_table_data_file(const char *db_dir, const char *table_name,
+                           char *errbuf, size_t errbuf_size);
+
+int append_row_to_table(const char *db_dir, const char *table_name,
+                        const Row *row,
+                        char *errbuf, size_t errbuf_size);
+
+int read_all_rows_from_table(const char *db_dir, const char *table_name,
+                             size_t expected_column_count,
+                             Row **out_rows, size_t *out_row_count,
+                             char *errbuf, size_t errbuf_size);
+
+void free_rows(Row *rows, size_t row_count);
+
+#endif

--- a/src/schema.c
+++ b/src/schema.c
@@ -1,0 +1,312 @@
+#include "schema.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void set_error(char *errbuf, size_t errbuf_size, const char *fmt, ...) {
+    va_list args;
+
+    if (errbuf == NULL || errbuf_size == 0U) {
+        return;
+    }
+
+    va_start(args, fmt);
+    vsnprintf(errbuf, errbuf_size, fmt, args);
+    va_end(args);
+}
+
+static char *duplicate_string(const char *src) {
+    size_t len;
+    char *copy;
+
+    if (src == NULL) {
+        return NULL;
+    }
+
+    len = strlen(src) + 1U;
+    copy = (char *)malloc(len);
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, src, len);
+    return copy;
+}
+
+static char *build_table_path(const char *db_dir, const char *table_name, const char *suffix) {
+    size_t db_len;
+    size_t table_len;
+    size_t suffix_len;
+    int needs_separator;
+    size_t total_len;
+    char *path;
+
+    db_len = strlen(db_dir);
+    table_len = strlen(table_name);
+    suffix_len = strlen(suffix);
+    needs_separator = (db_len > 0U && db_dir[db_len - 1U] != '/' && db_dir[db_len - 1U] != '\\') ? 1 : 0;
+    total_len = db_len + (size_t)needs_separator + table_len + suffix_len + 1U;
+
+    path = (char *)malloc(total_len);
+    if (path == NULL) {
+        return NULL;
+    }
+
+    snprintf(path, total_len, "%s%s%s%s", db_dir, needs_separator ? "/" : "", table_name, suffix);
+    return path;
+}
+
+static void trim_in_place(char *text) {
+    char *start;
+    char *end;
+    size_t trimmed_len;
+
+    if (text == NULL) {
+        return;
+    }
+
+    start = text;
+    while (*start != '\0' && isspace((unsigned char)*start)) {
+        start++;
+    }
+
+    end = start + strlen(start);
+    while (end > start && isspace((unsigned char)end[-1])) {
+        end--;
+    }
+
+    trimmed_len = (size_t)(end - start);
+    if (start != text) {
+        memmove(text, start, trimmed_len);
+    }
+    text[trimmed_len] = '\0';
+}
+
+static int read_line(FILE *file, char **out_line) {
+    size_t capacity;
+    size_t length;
+    char *buffer;
+    int ch;
+
+    if (out_line == NULL) {
+        return -1;
+    }
+
+    *out_line = NULL;
+    capacity = 128U;
+    length = 0U;
+    buffer = (char *)malloc(capacity);
+    if (buffer == NULL) {
+        return -1;
+    }
+
+    while ((ch = fgetc(file)) != EOF) {
+        if (ch == '\n') {
+            break;
+        }
+
+        if (length + 1U >= capacity) {
+            char *grown;
+
+            capacity *= 2U;
+            grown = (char *)realloc(buffer, capacity);
+            if (grown == NULL) {
+                free(buffer);
+                return -1;
+            }
+            buffer = grown;
+        }
+
+        buffer[length++] = (char)ch;
+    }
+
+    if (ferror(file) != 0) {
+        free(buffer);
+        return -1;
+    }
+
+    if (ch == EOF && length == 0U) {
+        free(buffer);
+        return 0;
+    }
+
+    if (length > 0U && buffer[length - 1U] == '\r') {
+        length--;
+    }
+
+    buffer[length] = '\0';
+    *out_line = buffer;
+    return 1;
+}
+
+static void free_string_array(char **items, size_t count) {
+    size_t i;
+
+    if (items == NULL) {
+        return;
+    }
+
+    for (i = 0U; i < count; i++) {
+        free(items[i]);
+    }
+    free(items);
+}
+
+static int append_column(char ***columns, size_t *column_count, const char *column_name) {
+    char *copy;
+    char **grown;
+
+    copy = duplicate_string(column_name);
+    if (copy == NULL) {
+        return 1;
+    }
+
+    grown = (char **)realloc(*columns, (*column_count + 1U) * sizeof(char *));
+    if (grown == NULL) {
+        free(copy);
+        return 1;
+    }
+
+    grown[*column_count] = copy;
+    *columns = grown;
+    *column_count += 1U;
+    return 0;
+}
+
+int load_table_schema(const char *db_dir, const char *table_name,
+                      TableSchema *out_schema,
+                      char *errbuf, size_t errbuf_size) {
+    char *schema_path;
+    FILE *file;
+    char **columns;
+    size_t column_count;
+    int read_status;
+    int status;
+
+    if (out_schema != NULL) {
+        out_schema->table_name = NULL;
+        out_schema->columns = NULL;
+        out_schema->column_count = 0U;
+    }
+
+    if (db_dir == NULL || table_name == NULL || out_schema == NULL) {
+        set_error(errbuf, errbuf_size, "invalid schema load arguments");
+        return 1;
+    }
+
+    schema_path = build_table_path(db_dir, table_name, ".schema");
+    if (schema_path == NULL) {
+        set_error(errbuf, errbuf_size, "failed to allocate schema path for table '%s'", table_name);
+        return 1;
+    }
+
+    file = fopen(schema_path, "r");
+    if (file == NULL) {
+        if (errno == ENOENT) {
+            set_error(errbuf, errbuf_size, "table '%s' not found", table_name);
+        } else {
+            set_error(errbuf, errbuf_size, "failed to open schema file '%s': %s", schema_path, strerror(errno));
+        }
+        free(schema_path);
+        return 1;
+    }
+
+    columns = NULL;
+    column_count = 0U;
+    status = 0;
+
+    while (1) {
+        char *line;
+        size_t i;
+
+        read_status = read_line(file, &line);
+        if (read_status == 0) {
+            break;
+        }
+        if (read_status < 0) {
+            set_error(errbuf, errbuf_size, "failed to read schema file '%s'", schema_path);
+            status = 1;
+            break;
+        }
+
+        trim_in_place(line);
+        if (line[0] == '\0') {
+            free(line);
+            continue;
+        }
+
+        for (i = 0U; i < column_count; i++) {
+            if (strcmp(columns[i], line) == 0) {
+                set_error(errbuf, errbuf_size, "duplicate column '%s' in table '%s'", line, table_name);
+                status = 1;
+                break;
+            }
+        }
+
+        if (status == 0 && append_column(&columns, &column_count, line) != 0) {
+            set_error(errbuf, errbuf_size, "failed to allocate schema column '%s'", line);
+            status = 1;
+        }
+
+        free(line);
+        if (status != 0) {
+            break;
+        }
+    }
+
+    fclose(file);
+    free(schema_path);
+
+    if (status == 0 && column_count == 0U) {
+        set_error(errbuf, errbuf_size, "table '%s' has no columns", table_name);
+        status = 1;
+    }
+
+    if (status != 0) {
+        free_string_array(columns, column_count);
+        return 1;
+    }
+
+    out_schema->table_name = duplicate_string(table_name);
+    if (out_schema->table_name == NULL) {
+        free_string_array(columns, column_count);
+        set_error(errbuf, errbuf_size, "failed to allocate schema table name '%s'", table_name);
+        return 1;
+    }
+
+    out_schema->columns = columns;
+    out_schema->column_count = column_count;
+    return 0;
+}
+
+int schema_find_column_index(const TableSchema *schema, const char *column_name) {
+    size_t i;
+
+    if (schema == NULL || column_name == NULL) {
+        return -1;
+    }
+
+    for (i = 0U; i < schema->column_count; i++) {
+        if (schema->columns[i] != NULL && strcmp(schema->columns[i], column_name) == 0) {
+            return (int)i;
+        }
+    }
+
+    return -1;
+}
+
+void free_table_schema(TableSchema *schema) {
+    if (schema == NULL) {
+        return;
+    }
+
+    free(schema->table_name);
+    free_string_array(schema->columns, schema->column_count);
+    schema->table_name = NULL;
+    schema->columns = NULL;
+    schema->column_count = 0U;
+}

--- a/src/storage.c
+++ b/src/storage.c
@@ -1,0 +1,594 @@
+#include "storage.h"
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void set_error(char *errbuf, size_t errbuf_size, const char *fmt, ...) {
+    va_list args;
+
+    if (errbuf == NULL || errbuf_size == 0U) {
+        return;
+    }
+
+    va_start(args, fmt);
+    vsnprintf(errbuf, errbuf_size, fmt, args);
+    va_end(args);
+}
+
+static char *duplicate_string(const char *src) {
+    size_t len;
+    char *copy;
+
+    if (src == NULL) {
+        return NULL;
+    }
+
+    len = strlen(src) + 1U;
+    copy = (char *)malloc(len);
+    if (copy == NULL) {
+        return NULL;
+    }
+
+    memcpy(copy, src, len);
+    return copy;
+}
+
+static char *build_table_path(const char *db_dir, const char *table_name, const char *suffix) {
+    size_t db_len;
+    size_t table_len;
+    size_t suffix_len;
+    int needs_separator;
+    size_t total_len;
+    char *path;
+
+    db_len = strlen(db_dir);
+    table_len = strlen(table_name);
+    suffix_len = strlen(suffix);
+    needs_separator = (db_len > 0U && db_dir[db_len - 1U] != '/' && db_dir[db_len - 1U] != '\\') ? 1 : 0;
+    total_len = db_len + (size_t)needs_separator + table_len + suffix_len + 1U;
+
+    path = (char *)malloc(total_len);
+    if (path == NULL) {
+        return NULL;
+    }
+
+    snprintf(path, total_len, "%s%s%s%s", db_dir, needs_separator ? "/" : "", table_name, suffix);
+    return path;
+}
+
+static int read_line(FILE *file, char **out_line) {
+    size_t capacity;
+    size_t length;
+    char *buffer;
+    int ch;
+
+    if (out_line == NULL) {
+        return -1;
+    }
+
+    *out_line = NULL;
+    capacity = 128U;
+    length = 0U;
+    buffer = (char *)malloc(capacity);
+    if (buffer == NULL) {
+        return -1;
+    }
+
+    while ((ch = fgetc(file)) != EOF) {
+        if (ch == '\n') {
+            break;
+        }
+
+        if (length + 1U >= capacity) {
+            char *grown;
+
+            capacity *= 2U;
+            grown = (char *)realloc(buffer, capacity);
+            if (grown == NULL) {
+                free(buffer);
+                return -1;
+            }
+            buffer = grown;
+        }
+
+        buffer[length++] = (char)ch;
+    }
+
+    if (ferror(file) != 0) {
+        free(buffer);
+        return -1;
+    }
+
+    if (ch == EOF && length == 0U) {
+        free(buffer);
+        return 0;
+    }
+
+    if (length > 0U && buffer[length - 1U] == '\r') {
+        length--;
+    }
+
+    buffer[length] = '\0';
+    *out_line = buffer;
+    return 1;
+}
+
+static int append_char(char **buffer, size_t *length, size_t *capacity, char ch) {
+    if (*buffer == NULL) {
+        *capacity = 32U;
+        *buffer = (char *)malloc(*capacity);
+        if (*buffer == NULL) {
+            return 1;
+        }
+        *length = 0U;
+    }
+
+    if (*length + 1U >= *capacity) {
+        char *grown;
+
+        *capacity *= 2U;
+        grown = (char *)realloc(*buffer, *capacity);
+        if (grown == NULL) {
+            return 1;
+        }
+        *buffer = grown;
+    }
+
+    (*buffer)[(*length)++] = ch;
+    return 0;
+}
+
+static int push_field(char ***fields, size_t *field_count, char *field_value) {
+    char **grown;
+
+    grown = (char **)realloc(*fields, (*field_count + 1U) * sizeof(char *));
+    if (grown == NULL) {
+        return 1;
+    }
+
+    grown[*field_count] = field_value;
+    *fields = grown;
+    *field_count += 1U;
+    return 0;
+}
+
+static void free_field_array(char **fields, size_t field_count) {
+    size_t i;
+
+    if (fields == NULL) {
+        return;
+    }
+
+    for (i = 0U; i < field_count; i++) {
+        free(fields[i]);
+    }
+    free(fields);
+}
+
+static char *escape_field(const char *value) {
+    const char *src;
+    size_t out_len;
+    char *escaped;
+    char *dst;
+
+    src = (value == NULL) ? "" : value;
+    out_len = 0U;
+    while (*src != '\0') {
+        if (*src == '\\' || *src == '|' || *src == '\n') {
+            out_len += 2U;
+        } else {
+            out_len += 1U;
+        }
+        src++;
+    }
+
+    escaped = (char *)malloc(out_len + 1U);
+    if (escaped == NULL) {
+        return NULL;
+    }
+
+    src = (value == NULL) ? "" : value;
+    dst = escaped;
+    while (*src != '\0') {
+        if (*src == '\\') {
+            *dst++ = '\\';
+            *dst++ = '\\';
+        } else if (*src == '|') {
+            *dst++ = '\\';
+            *dst++ = '|';
+        } else if (*src == '\n') {
+            *dst++ = '\\';
+            *dst++ = 'n';
+        } else {
+            *dst++ = *src;
+        }
+        src++;
+    }
+
+    *dst = '\0';
+    return escaped;
+}
+
+static char *unescape_field(const char *value) {
+    size_t len;
+    char *unescaped;
+    size_t src_index;
+    size_t dst_index;
+
+    if (value == NULL) {
+        return NULL;
+    }
+
+    len = strlen(value);
+    unescaped = (char *)malloc(len + 1U);
+    if (unescaped == NULL) {
+        return NULL;
+    }
+
+    dst_index = 0U;
+    for (src_index = 0U; src_index < len; src_index++) {
+        if (value[src_index] != '\\') {
+            unescaped[dst_index++] = value[src_index];
+            continue;
+        }
+
+        if (src_index + 1U >= len) {
+            free(unescaped);
+            return NULL;
+        }
+
+        src_index++;
+        if (value[src_index] == '\\') {
+            unescaped[dst_index++] = '\\';
+        } else if (value[src_index] == '|') {
+            unescaped[dst_index++] = '|';
+        } else if (value[src_index] == 'n') {
+            unescaped[dst_index++] = '\n';
+        } else {
+            free(unescaped);
+            return NULL;
+        }
+    }
+
+    unescaped[dst_index] = '\0';
+    return unescaped;
+}
+
+static int split_escaped_row(const char *line, char ***out_fields, size_t *out_count) {
+    char **fields;
+    size_t field_count;
+    char *current_raw;
+    size_t current_len;
+    size_t current_capacity;
+    int escape_pending;
+    const char *cursor;
+
+    if (line == NULL || out_fields == NULL || out_count == NULL) {
+        return 1;
+    }
+
+    *out_fields = NULL;
+    *out_count = 0U;
+    fields = NULL;
+    field_count = 0U;
+    current_raw = NULL;
+    current_len = 0U;
+    current_capacity = 0U;
+    escape_pending = 0;
+
+    for (cursor = line; *cursor != '\0'; cursor++) {
+        if (escape_pending != 0) {
+            if (append_char(&current_raw, &current_len, &current_capacity, *cursor) != 0) {
+                free_field_array(fields, field_count);
+                free(current_raw);
+                return 1;
+            }
+            escape_pending = 0;
+            continue;
+        }
+
+        if (*cursor == '\\') {
+            if (append_char(&current_raw, &current_len, &current_capacity, *cursor) != 0) {
+                free_field_array(fields, field_count);
+                free(current_raw);
+                return 1;
+            }
+            escape_pending = 1;
+            continue;
+        }
+
+        if (*cursor == '|') {
+            char *field_value;
+
+            if (append_char(&current_raw, &current_len, &current_capacity, '\0') != 0) {
+                free_field_array(fields, field_count);
+                free(current_raw);
+                return 1;
+            }
+
+            field_value = unescape_field(current_raw);
+            if (field_value == NULL || push_field(&fields, &field_count, field_value) != 0) {
+                free(field_value);
+                free_field_array(fields, field_count);
+                free(current_raw);
+                return 1;
+            }
+
+            current_len = 0U;
+            continue;
+        }
+
+        if (append_char(&current_raw, &current_len, &current_capacity, *cursor) != 0) {
+            free_field_array(fields, field_count);
+            free(current_raw);
+            return 1;
+        }
+    }
+
+    if (escape_pending != 0) {
+        free_field_array(fields, field_count);
+        free(current_raw);
+        return 1;
+    }
+
+    if (append_char(&current_raw, &current_len, &current_capacity, '\0') != 0) {
+        free_field_array(fields, field_count);
+        free(current_raw);
+        return 1;
+    }
+
+    {
+        char *field_value;
+
+        field_value = unescape_field(current_raw);
+        if (field_value == NULL || push_field(&fields, &field_count, field_value) != 0) {
+            free(field_value);
+            free_field_array(fields, field_count);
+            free(current_raw);
+            return 1;
+        }
+    }
+
+    free(current_raw);
+    *out_fields = fields;
+    *out_count = field_count;
+    return 0;
+}
+
+int ensure_table_data_file(const char *db_dir, const char *table_name,
+                           char *errbuf, size_t errbuf_size) {
+    char *data_path;
+    FILE *file;
+
+    if (db_dir == NULL || table_name == NULL) {
+        set_error(errbuf, errbuf_size, "invalid data file arguments");
+        return 1;
+    }
+
+    data_path = build_table_path(db_dir, table_name, ".data");
+    if (data_path == NULL) {
+        set_error(errbuf, errbuf_size, "failed to allocate data path for table '%s'", table_name);
+        return 1;
+    }
+
+    file = fopen(data_path, "ab");
+    if (file == NULL) {
+        set_error(errbuf, errbuf_size, "failed to open data file '%s': %s", data_path, strerror(errno));
+        free(data_path);
+        return 1;
+    }
+
+    fclose(file);
+    free(data_path);
+    return 0;
+}
+
+int append_row_to_table(const char *db_dir, const char *table_name,
+                        const Row *row,
+                        char *errbuf, size_t errbuf_size) {
+    char *data_path;
+    FILE *file;
+    size_t i;
+    int status;
+
+    if (db_dir == NULL || table_name == NULL || row == NULL) {
+        set_error(errbuf, errbuf_size, "invalid row append arguments");
+        return 1;
+    }
+
+    if (row->value_count == 0U) {
+        set_error(errbuf, errbuf_size, "cannot append an empty row to table '%s'", table_name);
+        return 1;
+    }
+
+    if (ensure_table_data_file(db_dir, table_name, errbuf, errbuf_size) != 0) {
+        return 1;
+    }
+
+    data_path = build_table_path(db_dir, table_name, ".data");
+    if (data_path == NULL) {
+        set_error(errbuf, errbuf_size, "failed to allocate data path for table '%s'", table_name);
+        return 1;
+    }
+
+    file = fopen(data_path, "ab");
+    if (file == NULL) {
+        set_error(errbuf, errbuf_size, "failed to append data file '%s': %s", data_path, strerror(errno));
+        free(data_path);
+        return 1;
+    }
+
+    status = 0;
+    for (i = 0U; i < row->value_count; i++) {
+        char *escaped;
+
+        escaped = escape_field(row->values[i]);
+        if (escaped == NULL) {
+            set_error(errbuf, errbuf_size, "failed to escape row value for table '%s'", table_name);
+            status = 1;
+            break;
+        }
+
+        if ((i > 0U && fputc('|', file) == EOF) || fputs(escaped, file) == EOF) {
+            set_error(errbuf, errbuf_size, "failed to write row data to '%s'", data_path);
+            free(escaped);
+            status = 1;
+            break;
+        }
+
+        free(escaped);
+    }
+
+    if (status == 0 && fputc('\n', file) == EOF) {
+        set_error(errbuf, errbuf_size, "failed to terminate row in '%s'", data_path);
+        status = 1;
+    }
+
+    if (fclose(file) != 0 && status == 0) {
+        set_error(errbuf, errbuf_size, "failed to finalize data file '%s'", data_path);
+        status = 1;
+    }
+
+    free(data_path);
+    return status;
+}
+
+int read_all_rows_from_table(const char *db_dir, const char *table_name,
+                             size_t expected_column_count,
+                             Row **out_rows, size_t *out_row_count,
+                             char *errbuf, size_t errbuf_size) {
+    char *data_path;
+    FILE *file;
+    Row *rows;
+    size_t row_count;
+    int status;
+    size_t line_number;
+
+    if (out_rows != NULL) {
+        *out_rows = NULL;
+    }
+    if (out_row_count != NULL) {
+        *out_row_count = 0U;
+    }
+
+    if (db_dir == NULL || table_name == NULL || out_rows == NULL || out_row_count == NULL) {
+        set_error(errbuf, errbuf_size, "invalid row read arguments");
+        return 1;
+    }
+
+    data_path = build_table_path(db_dir, table_name, ".data");
+    if (data_path == NULL) {
+        set_error(errbuf, errbuf_size, "failed to allocate data path for table '%s'", table_name);
+        return 1;
+    }
+
+    file = fopen(data_path, "rb");
+    if (file == NULL) {
+        if (errno == ENOENT) {
+            free(data_path);
+            return 0;
+        }
+
+        set_error(errbuf, errbuf_size, "failed to open data file '%s': %s", data_path, strerror(errno));
+        free(data_path);
+        return 1;
+    }
+
+    rows = NULL;
+    row_count = 0U;
+    status = 0;
+    line_number = 0U;
+
+    while (1) {
+        char *line;
+        int read_status;
+
+        read_status = read_line(file, &line);
+        if (read_status == 0) {
+            break;
+        }
+        if (read_status < 0) {
+            set_error(errbuf, errbuf_size, "failed to read data file '%s'", data_path);
+            status = 1;
+            break;
+        }
+
+        line_number++;
+
+        {
+            char **fields;
+            size_t field_count;
+            Row *grown_rows;
+
+            if (split_escaped_row(line, &fields, &field_count) != 0) {
+                set_error(errbuf, errbuf_size, "malformed row %zu in table '%s'", line_number, table_name);
+                free(line);
+                status = 1;
+                break;
+            }
+
+            if (field_count != expected_column_count) {
+                set_error(errbuf, errbuf_size,
+                          "malformed row %zu in table '%s': expected %zu columns but found %zu",
+                          line_number, table_name, expected_column_count, field_count);
+                free_field_array(fields, field_count);
+                free(line);
+                status = 1;
+                break;
+            }
+
+            grown_rows = (Row *)realloc(rows, (row_count + 1U) * sizeof(Row));
+            if (grown_rows == NULL) {
+                set_error(errbuf, errbuf_size, "failed to allocate row array for table '%s'", table_name);
+                free_field_array(fields, field_count);
+                free(line);
+                status = 1;
+                break;
+            }
+
+            rows = grown_rows;
+            rows[row_count].values = fields;
+            rows[row_count].value_count = field_count;
+            row_count += 1U;
+        }
+
+        free(line);
+    }
+
+    if (fclose(file) != 0 && status == 0) {
+        set_error(errbuf, errbuf_size, "failed to close data file '%s'", data_path);
+        status = 1;
+    }
+
+    free(data_path);
+
+    if (status != 0) {
+        free_rows(rows, row_count);
+        return 1;
+    }
+
+    *out_rows = rows;
+    *out_row_count = row_count;
+    return 0;
+}
+
+void free_rows(Row *rows, size_t row_count) {
+    size_t i;
+
+    if (rows == NULL) {
+        return;
+    }
+
+    for (i = 0U; i < row_count; i++) {
+        free_field_array(rows[i].values, rows[i].value_count);
+        rows[i].values = NULL;
+        rows[i].value_count = 0U;
+    }
+
+    free(rows);
+}
+
+

--- a/tests/test_storage.c
+++ b/tests/test_storage.c
@@ -1,0 +1,281 @@
+#include "schema.h"
+#include "storage.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <direct.h>
+#define MKDIR(path) _mkdir(path)
+#define RMDIR(path) _rmdir(path)
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#define MKDIR(path) mkdir((path), 0777)
+#define RMDIR(path) rmdir(path)
+#endif
+
+static int tests_failed = 0;
+
+static void fail_test(const char *message, const char *file, int line) {
+    fprintf(stderr, "TEST FAILED at %s:%d: %s\n", file, line, message);
+    tests_failed = 1;
+}
+
+#define ASSERT_TRUE(expr) do { \
+    if (!(expr)) { \
+        fail_test(#expr, __FILE__, __LINE__); \
+        return; \
+    } \
+} while (0)
+
+#define ASSERT_STREQ(expected, actual) do { \
+    if (strcmp((expected), (actual)) != 0) { \
+        char _message[512]; \
+        snprintf(_message, sizeof(_message), "expected '%s' but got '%s'", (expected), (actual)); \
+        fail_test(_message, __FILE__, __LINE__); \
+        return; \
+    } \
+} while (0)
+
+static void remove_if_exists(const char *path) {
+    remove(path);
+}
+
+static void ensure_directory(const char *path) {
+    if (MKDIR(path) != 0 && errno != EEXIST) {
+        fprintf(stderr, "Failed to create directory %s: %s\n", path, strerror(errno));
+        exit(1);
+    }
+}
+
+static void cleanup_test_db(void) {
+    remove_if_exists("tests/tmp_storage_db/users.schema");
+    remove_if_exists("tests/tmp_storage_db/users.data");
+    remove_if_exists("tests/tmp_storage_db/dupe.schema");
+    RMDIR("tests/tmp_storage_db");
+}
+
+static void prepare_test_db(void) {
+    FILE *schema_file;
+
+    cleanup_test_db();
+    ensure_directory("tests");
+    ensure_directory("tests/tmp_storage_db");
+
+    schema_file = fopen("tests/tmp_storage_db/users.schema", "w");
+    if (schema_file == NULL) {
+        fprintf(stderr, "Failed to open schema file: %s\n", strerror(errno));
+        exit(1);
+    }
+
+    fputs("id\nname\nage\n", schema_file);
+    fclose(schema_file);
+}
+
+static char *read_entire_file(const char *path) {
+    FILE *file;
+    long length;
+    char *buffer;
+    size_t read_size;
+
+    file = fopen(path, "rb");
+    if (file == NULL) {
+        return NULL;
+    }
+
+    if (fseek(file, 0L, SEEK_END) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    length = ftell(file);
+    if (length < 0L) {
+        fclose(file);
+        return NULL;
+    }
+
+    if (fseek(file, 0L, SEEK_SET) != 0) {
+        fclose(file);
+        return NULL;
+    }
+
+    buffer = (char *)malloc((size_t)length + 1U);
+    if (buffer == NULL) {
+        fclose(file);
+        return NULL;
+    }
+
+    read_size = fread(buffer, 1U, (size_t)length, file);
+    buffer[read_size] = '\0';
+    fclose(file);
+    return buffer;
+}
+
+static void test_load_table_schema_success(void) {
+    TableSchema schema = {0};
+    char errbuf[256] = {0};
+
+    prepare_test_db();
+
+    ASSERT_TRUE(load_table_schema("tests/tmp_storage_db", "users", &schema, errbuf, sizeof(errbuf)) == 0);
+    ASSERT_TRUE(schema.column_count == 3U);
+    ASSERT_STREQ("users", schema.table_name);
+    ASSERT_STREQ("id", schema.columns[0]);
+    ASSERT_STREQ("name", schema.columns[1]);
+    ASSERT_STREQ("age", schema.columns[2]);
+    ASSERT_TRUE(schema_find_column_index(&schema, "name") == 1);
+    ASSERT_TRUE(schema_find_column_index(&schema, "missing") == -1);
+
+    free_table_schema(&schema);
+}
+
+static void test_duplicate_schema_column_error(void) {
+    FILE *schema_file;
+    TableSchema schema = {0};
+    char errbuf[256] = {0};
+
+    prepare_test_db();
+
+    schema_file = fopen("tests/tmp_storage_db/dupe.schema", "w");
+    if (schema_file == NULL) {
+        fprintf(stderr, "Failed to open duplicate schema file: %s\n", strerror(errno));
+        exit(1);
+    }
+
+    fputs("id\nname\nid\n", schema_file);
+    fclose(schema_file);
+
+    ASSERT_TRUE(load_table_schema("tests/tmp_storage_db", "dupe", &schema, errbuf, sizeof(errbuf)) != 0);
+    ASSERT_TRUE(strstr(errbuf, "duplicate column") != NULL);
+    free_table_schema(&schema);
+}
+
+static void test_append_row_escapes_fields(void) {
+    Row row = {0};
+    char *values[3];
+    char errbuf[256] = {0};
+    char *content;
+
+    prepare_test_db();
+
+    values[0] = "1";
+    values[1] = "Alice|Admin";
+    values[2] = "line1\nline2\\done";
+    row.values = values;
+    row.value_count = 3U;
+
+    ASSERT_TRUE(append_row_to_table("tests/tmp_storage_db", "users", &row, errbuf, sizeof(errbuf)) == 0);
+
+    content = read_entire_file("tests/tmp_storage_db/users.data");
+    ASSERT_TRUE(content != NULL);
+    ASSERT_STREQ("1|Alice\\|Admin|line1\\nline2\\\\done\n", content);
+    free(content);
+}
+
+static void test_read_rows_round_trip_escape_sequences(void) {
+    Row row = {0};
+    Row *rows = NULL;
+    size_t row_count = 0U;
+    char *values[3];
+    char errbuf[256] = {0};
+
+    prepare_test_db();
+
+    values[0] = "7";
+    values[1] = "Bob|Builder";
+    values[2] = "hello\npath\\value";
+    row.values = values;
+    row.value_count = 3U;
+
+    ASSERT_TRUE(append_row_to_table("tests/tmp_storage_db", "users", &row, errbuf, sizeof(errbuf)) == 0);
+    ASSERT_TRUE(read_all_rows_from_table("tests/tmp_storage_db", "users", 3U, &rows, &row_count, errbuf, sizeof(errbuf)) == 0);
+    ASSERT_TRUE(row_count == 1U);
+    ASSERT_TRUE(rows[0].value_count == 3U);
+    ASSERT_STREQ("7", rows[0].values[0]);
+    ASSERT_STREQ("Bob|Builder", rows[0].values[1]);
+    ASSERT_STREQ("hello\npath\\value", rows[0].values[2]);
+
+    free_rows(rows, row_count);
+}
+
+static void test_read_missing_data_file_as_empty_table(void) {
+    Row *rows = NULL;
+    size_t row_count = 0U;
+    char errbuf[256] = {0};
+
+    prepare_test_db();
+    remove_if_exists("tests/tmp_storage_db/users.data");
+
+    ASSERT_TRUE(read_all_rows_from_table("tests/tmp_storage_db", "users", 3U, &rows, &row_count, errbuf, sizeof(errbuf)) == 0);
+    ASSERT_TRUE(rows == NULL);
+    ASSERT_TRUE(row_count == 0U);
+}
+
+static void test_read_empty_data_file(void) {
+    FILE *data_file;
+    Row *rows = NULL;
+    size_t row_count = 0U;
+    char errbuf[256] = {0};
+
+    prepare_test_db();
+
+    data_file = fopen("tests/tmp_storage_db/users.data", "w");
+    if (data_file == NULL) {
+        fprintf(stderr, "Failed to create empty data file: %s\n", strerror(errno));
+        exit(1);
+    }
+    fclose(data_file);
+
+    ASSERT_TRUE(read_all_rows_from_table("tests/tmp_storage_db", "users", 3U, &rows, &row_count, errbuf, sizeof(errbuf)) == 0);
+    ASSERT_TRUE(rows == NULL);
+    ASSERT_TRUE(row_count == 0U);
+}
+
+static void test_malformed_row_column_count_error(void) {
+    FILE *data_file;
+    Row *rows = NULL;
+    size_t row_count = 0U;
+    char errbuf[256] = {0};
+
+    prepare_test_db();
+
+    data_file = fopen("tests/tmp_storage_db/users.data", "w");
+    if (data_file == NULL) {
+        fprintf(stderr, "Failed to create malformed data file: %s\n", strerror(errno));
+        exit(1);
+    }
+
+    fputs("1|Alice\n", data_file);
+    fclose(data_file);
+
+    ASSERT_TRUE(read_all_rows_from_table("tests/tmp_storage_db", "users", 3U, &rows, &row_count, errbuf, sizeof(errbuf)) != 0);
+    ASSERT_TRUE(strstr(errbuf, "expected 3 columns but found 2") != NULL);
+    ASSERT_TRUE(rows == NULL);
+    ASSERT_TRUE(row_count == 0U);
+}
+
+int main(void) {
+    test_load_table_schema_success();
+    test_duplicate_schema_column_error();
+    test_append_row_escapes_fields();
+    test_read_rows_round_trip_escape_sequences();
+    test_read_missing_data_file_as_empty_table();
+    test_read_empty_data_file();
+    test_malformed_row_column_count_error();
+
+    cleanup_test_db();
+
+    if (tests_failed != 0) {
+        return 1;
+    }
+
+    printf("test_storage: ok\n");
+    return 0;
+}
+
+
+


### PR DESCRIPTION
﻿## 요약
B 작업 범위에 해당하는 schema/storage 레이어를 구현했습니다.

## 변경 사항
- `TableSchema`, `Row` 계약을 `include/schema.h`, `include/storage.h`에 추가
- `.schema` 파일 로드와 중복 column/빈 schema 검증 로직 구현
- `.data` 파일 생성, row append/read, malformed row 방어 구현
- `\\`, `|`, 개행에 대한 escape/unescape 처리 구현
- storage 단위 테스트와 샘플 schema 파일 추가

## 테스트
- MSVC `cl /W4 /WX /D_CRT_SECURE_NO_WARNINGS /I include src\\schema.c src\\storage.c tests\\test_storage.c` 빌드 통과
- `tests\\test_storage.exe` 실행 통과 (`test_storage: ok`)

## 비고
- 현재 워킹트리의 미커밋 파일(`scripts/install_codex_skills.*`, `.tools/`)은 이 PR에 포함되지 않았습니다.

Closes #3
